### PR TITLE
Bugfix list of months in YearStats

### DIFF
--- a/src/views/orders/YearStats.vue
+++ b/src/views/orders/YearStats.vue
@@ -186,13 +186,13 @@ export default {
         const { statusesData, yearData } = await yearModel.getYearData(this.statuscodes)
 
         // fill bar graph data and set labels/fields
-        let monthDataBar = [], monthDataPie = [], labels = [], colors = []
+        let monthDataBar = [], monthDataPie = [], colors = []
+        const labels = this.$moment.monthsShort()
+
         for (let i=0; i<12; i++) {
-          const monthText =  i < 10 ? `0${i + 1}` : `${i}`
-          const date = this.$moment(`${this.year}-${monthText}-1`, 'D-MM-YYYY')
-          const monthTextLong = date.format('MMM')
-          labels.push(monthTextLong)
+          const monthText = (i + 1).toString().padStart(2, '0')
           colors.push(this.getRandomColor(monthText))
+          
           if (monthText in yearData.items) {
             monthDataBar.push(yearData.items[monthText].count)
             monthDataPie.push(yearData.items[monthText].perc)


### PR DESCRIPTION
The bug was that the list of months would come out incorrectly, see here:

<img width="1178" height="108" alt="signal-2026-05-07-163333_002" src="https://github.com/user-attachments/assets/4d97ade7-38ba-4748-91ae-717954a7be69" />

This commit fixes that