### PR TITLE
Add order types pie chart in equipment detail & hide buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 
 
 # local env files
+.env
 .env.local
 .env.*.local
 

--- a/src/components/OrderTypesPie.vue
+++ b/src/components/OrderTypesPie.vue
@@ -4,6 +4,17 @@ import {OrderService} from "@/models/orders/Order.js";
 import PieChart from "@/components/PieChart.vue"
 // import ChartJsPluginDataLabels from "chartjs-plugin-datalabels";
 
+const props = defineProps({
+  equipmentPk: {
+    type: [Number, String],
+    required: false
+  },
+  locationPk: {
+    type: [Number, String],
+    required: false
+  }
+})
+
 const chartdataOrderTypesPie = ref({})
 const isLoading = ref(false)
 const orderService = new OrderService()
@@ -40,7 +51,14 @@ function getRandomColorOrderType(txt) {
 async function fillPieData() {
   isLoading.value = true
   try {
-    const orderTypeStatsData = await orderService.getOrderTypesStatsBranch()
+    let orderTypeStatsData
+    if (props.equipmentPk) {
+      orderTypeStatsData = await orderService.getOrderTypesStatsEquipment(props.equipmentPk)
+    } else if (props.locationPk) {
+      orderTypeStatsData = await orderService.getOrderTypesStatsLocation(props.locationPk)
+    } else {
+      orderTypeStatsData = await orderService.getOrderTypesStatsBranch()
+    }
     const thresholdOrderType = .15
     for (const [orderType, _data] of Object.entries(orderTypeStatsData.order_types)) {
       if (parseFloat(_data.perc) > thresholdOrderType) {

--- a/src/components/WorkOrdersTable.vue
+++ b/src/components/WorkOrdersTable.vue
@@ -57,7 +57,7 @@ export default {
   },
   props: {
     equipmentPk: {
-      type: integer,
+      type: [Number, String],
       default: undefined
     },
     hideColumns: {

--- a/src/views/company/Startpage.vue
+++ b/src/views/company/Startpage.vue
@@ -332,7 +332,7 @@ import LogComponent from "./startpage/LogComponent.vue";
 import BranchPhotoCard from "./startpage/BranchPhotoCard.vue"
 import DashboardBlock from "./startpage/DashboardBlock.vue";
 import WorkOrdersTable from "@/components/WorkOrdersTable.vue";
-import OrderTypesPie from "./startpage/OrderTypesPie.vue";
+import OrderTypesPie from "../../components/OrderTypesPie.vue";
 
 let d = new Date()
 

--- a/src/views/equipment/EquipmentList.vue
+++ b/src/views/equipment/EquipmentList.vue
@@ -75,6 +75,7 @@
             />
           </BButton-group>
           <router-link
+            v-if="from_settings"
             :to="{name: newLink}"
             class="btn btn-primary"
           >{{ $trans("Add Equipment") }}</router-link>

--- a/src/views/equipment/equipment_view/EquipmentViewShltr.vue
+++ b/src/views/equipment/equipment_view/EquipmentViewShltr.vue
@@ -14,10 +14,10 @@
           <span class="backlink" @click="goBack">{{ this.$trans('Equipment') }}</span> /
           <span v-if="equipment">{{ equipment.name }}</span>
         </h3>
-        <BButton-toolbar>
+        <BButton-toolbar v-if="from_settings">
           <router-link
           :to="{name: editLink, params:{pk: this.pk}}"
-          class="btn"
+          class="btn btn-primary"
           >{{ `${$trans('Edit')} ${$trans('equipment')}`}}</router-link>
         </BButton-toolbar>
       </div>
@@ -157,7 +157,7 @@
         </div>
 
         <!-- Col 4: Documents -->
-        <div class="col-12 mb-4">
+        <div class="col-6 mb-4">
           <div class="card border-0 shadow-sm h-100">
             <div class="card-header py-3 bg-transparent border-bottom">
               <h5 class="mb-0 text-center text-primary">{{ this.$trans('Documents') }}</h5>
@@ -166,6 +166,18 @@
               <DocumentsComponent
                 :equipment="equipment"
                 :is-view="true"
+              />
+            </div>
+          </div>
+        </div>
+        <div class="col-6 mb-4">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-header py-3 bg-transparent border-bottom">
+              <h5 class="mb-0 text-center text-primary">{{ this.$trans('Order types') }}</h5>
+            </div>
+            <div class="card-body">
+              <OrderTypesPie
+                :equipment-pk="pk"
               />
             </div>
           </div>
@@ -186,6 +198,7 @@ import SearchModal from '@/components/SearchModal.vue'
 import DocumentsComponent from "@/views/equipment/equipment_form/DocumentsComponent.vue";
 import equipmentViewMixin from './equipmentViewMixin.js'
 import WorkOrdersTable from '@/components/WorkOrdersTable.vue'
+import OrderTypesPie from "@/components/OrderTypesPie.vue";
 
 export default {
   components: {
@@ -195,6 +208,13 @@ export default {
     OrderTableInfo,
     SearchModal,
     WorkOrdersTable,
+    OrderTypesPie,
+  },
+  props: {
+    from_settings: {
+      type: Boolean,
+      default: false
+    }
   },
   extends: equipmentViewMixin,
   setup(props, ctx) {

--- a/src/views/equipment/equipment_view/EquipmentViewShltr.vue
+++ b/src/views/equipment/equipment_view/EquipmentViewShltr.vue
@@ -157,7 +157,7 @@
         </div>
 
         <!-- Col 4: Documents -->
-        <div class="col-6 mb-4">
+        <div class="col-8 mb-4">
           <div class="card border-0 shadow-sm h-100">
             <div class="card-header py-3 bg-transparent border-bottom">
               <h5 class="mb-0 text-center text-primary">{{ this.$trans('Documents') }}</h5>
@@ -170,7 +170,7 @@
             </div>
           </div>
         </div>
-        <div class="col-6 mb-4">
+        <div class="col-4 mb-4">
           <div class="card border-0 shadow-sm h-100">
             <div class="card-header py-3 bg-transparent border-bottom">
               <h5 class="mb-0 text-center text-primary">{{ this.$trans('Order types') }}</h5>


### PR DESCRIPTION
- show order types pie chart in equipment detail
- hide edit/add buttons when not called from settings
