### PR TITLE
fix(workorder): keep the signature block on one page in the PDF

### DIFF
--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -90,6 +90,18 @@ details {
   .signature {
     height: 150px;
   }
+
+  // These documents are rendered to PDF by Chromium (Gotenberg). Keep blocks
+  // that belong together from being torn apart by a page break — especially
+  // the signatures, where a split leaves the images stranded on their own.
+  .avoid-page-break {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100%;
+  }
 }
 
 // TODO: fix markup?

--- a/src/views/orders/WorkorderMaintenance.vue
+++ b/src/views/orders/WorkorderMaintenance.vue
@@ -223,18 +223,18 @@
             </div>
         </div>
 
-        <div class="row" v-if="data.signatures">
+        <div class="row avoid-page-break" v-if="data.signatures">
             <div class="col-sm-12">
                 <p><b>{{ $trans('Signatures') }}</b></p>
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-6 avoid-page-break">
                 <div>
                     <p>{{ $trans('Name employee') }}: {{ data.signatures.signature_name_user }}</p>
                     <hr/>
                     <p><img width="400" :src="data.signatures.signature_user"></p>
                 </div>
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-6 avoid-page-break">
                 <div>
                     <p>{{ $trans('Name customer') }}: {{ data.signatures.signature_name_customer }}</p>
                     <hr/>


### PR DESCRIPTION
Dit fixt de taak "Handtekening werkbon: Handtekening valt weg", zie: https://op147.nl.tabdigital.eu/wp/46