### PR TITLE
feat: add email_ics option to actionTypes order in ActionForm

### DIFF
--- a/src/views/shared/ActionForm.vue
+++ b/src/views/shared/ActionForm.vue
@@ -446,6 +446,7 @@ export default {
       actionTypes: null,
       actionTypesOrder: [
         {value: 'email', text: this.$trans('send email')},
+        {value: 'email_ics', text: this.$trans('send email with calendar (ics) file')},
         {value: 'email_assigned', text: this.$trans('email assigned engineers')},
         {value: 'copy', text: this.$trans('copy order to partner')},
         {value: 'status', text: this.$trans('status change original order')},


### PR DESCRIPTION
Volgens mij is dit toch alles wat er nodig was? De e-mail velden blijven gewoon werken omdat in `"email_ics"` het woord `"email"` zit.